### PR TITLE
[FIX]Wrong Menu header name   for the resource type   Équip./Service

### DIFF
--- a/project_resource_calendar/i18n/fr.po
+++ b/project_resource_calendar/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-10-22 19:38+0000\n"
-"PO-Revision-Date: 2018-10-22 15:39-0400\n"
+"POT-Creation-Date: 2018-10-30 17:17+0000\n"
+"PO-Revision-Date: 2018-10-30 13:18-0400\n"
 "Last-Translator: Luis Garcia <luis.garcia@savoirfairelinux.com>\n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -86,7 +86,10 @@ msgid "Display Name"
 msgstr "Nom à afficher"
 
 #. module: project_resource_calendar
+#: model:ir.actions.act_window,name:project_resource_calendar.action_resource_instrument
 #: model:ir.ui.menu,name:project_resource_calendar.instrument_sub_menu
+#: model:ir.ui.view,arch_db:project_resource_calendar.resource_calendar_instrument_form
+#: model:ir.ui.view,arch_db:project_resource_calendar.resource_instrument_tree
 msgid "Equip./Service"
 msgstr "Équip./Service"
 
@@ -137,14 +140,11 @@ msgid "ID"
 msgstr "ID"
 
 #. module: project_resource_calendar
-#: model:ir.ui.view,arch_db:project_resource_calendar.resource_calendar_instrument_form
-#: model:ir.ui.view,arch_db:project_resource_calendar.resource_instrument_tree
 #: selection:resource.calendar.instrument,category_type:0
 msgid "Instrument"
 msgstr "Instrument"
 
 #. module: project_resource_calendar
-#: model:ir.actions.act_window,name:project_resource_calendar.action_resource_instrument
 #: model:ir.model.fields,field_description:project_resource_calendar.field_resource_calendar_room_instruments_ids
 msgid "Instruments"
 msgstr "Instruments"

--- a/project_resource_calendar/views/instrument_view.xml
+++ b/project_resource_calendar/views/instrument_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="action_resource_instrument" model="ir.actions.act_window">
-        <field name="name">Instruments</field>
+        <field name="name">Equip./Service</field>
         <field name="res_model">resource.calendar.instrument</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
@@ -12,10 +12,10 @@
               action="action_resource_instrument"
               sequence="16"/>
     <record id="resource_instrument_tree" model="ir.ui.view">
-        <field name="name">Instrument Tree</field>
+        <field name="name">Equip./Service Tree</field>
         <field name="model">resource.calendar.instrument</field>
         <field name="arch" type="xml">
-            <tree string="Instrument">
+            <tree string="Equip./Service">
                 <field name="name"/>
                 <field name="room_id"/>
                 <field name="sku"/>
@@ -24,10 +24,10 @@
         </field>
     </record>
     <record id="resource_calendar_instrument_form" model="ir.ui.view">
-        <field name="name">Instrument Form</field>
+        <field name="name">Equip./Service Form</field>
         <field name="model">resource.calendar.instrument</field>
         <field name="arch" type="xml">
-            <form string="Instrument">
+            <form string="Equip./Service">
                 <sheet>
                     <field name="photo" widget="image" class="oe_avatar" />
                     <div>


### PR DESCRIPTION
Fixing the wrong menu header name for the resource type  Équip./Service 