### PR TITLE
[FIX] Partner of project task required field

### DIFF
--- a/project_event/models/project_task.py
+++ b/project_event/models/project_task.py
@@ -44,7 +44,6 @@ class Task(models.Model):
         'res.partner',
         string='Client',
         track_visibility='onchange',
-        required=True,
     )
     client_type = fields.Many2one(
         'res.partner.category.type',


### PR DESCRIPTION
Partner of project task should be a required field, but to not break the tests, it is better to put it required in the project event task form view