### PR TITLE
[ADD] project task main task's description  field edit condition

### DIFF
--- a/project_event/models/project_task.py
+++ b/project_event/models/project_task.py
@@ -612,6 +612,9 @@ class Task(models.Model):
             if self.user_has_groups(
                     'project_event.group_project_event_editor'):
                 return
+            if self.is_main_task and self.user_has_groups(
+                    'project_event.group_project_event_user'):
+                vals.pop('description')
             else:
                 raise AccessError(
                     _('You cannot edit fields description and plans'))


### PR DESCRIPTION
Fixes issue of editing of the main task by project.event user when task is in ['requested', 'accepted'] and the task is of type 'main_task' by always removing description value during the write

\Introduced following functional problem:
If user makes a change of the description, he will not have any feedback telling him that his change was not taken into account.